### PR TITLE
hotfix: 공지사항 목록 및 검색 json변환 에러 해결

### DIFF
--- a/src/main/java/com/youngcamp/server/controller/AnnouncementController.java
+++ b/src/main/java/com/youngcamp/server/controller/AnnouncementController.java
@@ -66,7 +66,8 @@ public class AnnouncementController {
   public SuccessResponse<AnnouncementEditResponse> editAnnouncement(
       @PathVariable(name = "announcementId") Long announcementId,
       @RequestBody AnnouncementEditRequest request) {
-    AnnouncementEditResponse announcementEditResponse = announcementService.editAnnouncement(announcementId, request);
+    AnnouncementEditResponse announcementEditResponse =
+        announcementService.editAnnouncement(announcementId, request);
     return new SuccessResponse<>("공지사항 수정 성공", announcementEditResponse);
   }
 

--- a/src/main/java/com/youngcamp/server/controller/AnnouncementController.java
+++ b/src/main/java/com/youngcamp/server/controller/AnnouncementController.java
@@ -48,16 +48,16 @@ public class AnnouncementController {
   @Operation(summary = "공지사항 목록 조회 API", description = "존재하는 공지사항 목록을 조회합니다.")
   @GetMapping
   public SuccessResponse<List<AnnouncementGetResponse>> getAnnouncements() {
-    List<AnnouncementGetResponse> result = announcementService.getAnnouncements();
-    return new SuccessResponse<>("공지사항 목록 조회 성공", result);
+    List<Announcement> announcements = announcementService.getAnnouncements();
+    return new SuccessResponse<>("공지사항 목록 조회 성공", AnnouncementHelper.toDto(announcements));
   }
 
   @Operation(summary = "공지사항 상세 조회 API", description = "공지사항 ID값으로 특정 공지 사항 내용을 조회합니다.")
   @GetMapping("/{announcementId}")
   public SuccessResponse<AnnouncementGetDetailResponse> getDetailAnnouncement(
       @PathVariable(name = "announcementId") Long announcementId) {
-    Announcement result = announcementService.getDetailAnnouncement(announcementId);
-    return new SuccessResponse<>("공지사항 상세 조회 성공", AnnouncementHelper.toDto(result));
+    Announcement detailAnnouncement = announcementService.getDetailAnnouncement(announcementId);
+    return new SuccessResponse<>("공지사항 상세 조회 성공", AnnouncementHelper.toDto(detailAnnouncement));
   }
 
   @Operation(summary = "공지사항 수정 API", description = "공지사항 ID값으로 특정 공지 사항 내용을 수정합니다.")
@@ -66,8 +66,8 @@ public class AnnouncementController {
   public SuccessResponse<AnnouncementEditResponse> editAnnouncement(
       @PathVariable(name = "announcementId") Long announcementId,
       @RequestBody AnnouncementEditRequest request) {
-    AnnouncementEditResponse result = announcementService.editAnnouncement(announcementId, request);
-    return new SuccessResponse<>("공지사항 수정 성공", result);
+    AnnouncementEditResponse announcementEditResponse = announcementService.editAnnouncement(announcementId, request);
+    return new SuccessResponse<>("공지사항 수정 성공", announcementEditResponse);
   }
 
   @Operation(
@@ -76,7 +76,7 @@ public class AnnouncementController {
   @GetMapping("/search")
   public SuccessResponse<List<AnnouncementGetResponse>> searchAnnouncements(
       @RequestParam(name = "keyword") String keyword) {
-    List<AnnouncementGetResponse> result = announcementService.searchAnnouncements(keyword);
-    return new SuccessResponse<>("공지사항 검색 성공", result);
+    List<Announcement> announcements = announcementService.searchAnnouncements(keyword);
+    return new SuccessResponse<>("공지사항 검색 성공", AnnouncementHelper.toDto(announcements));
   }
 }

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
@@ -1,7 +1,5 @@
 package com.youngcamp.server.dto;
 
-import com.youngcamp.server.domain.Announcement;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
@@ -25,24 +25,19 @@ public class AnnouncementResponse {
   @Getter
   @AllArgsConstructor
   @NoArgsConstructor
+  @Builder
   public static class AnnouncementGetResponse {
     private Long id;
     private String title;
     private Boolean isPinned;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    @Builder
-    public AnnouncementGetResponse(Announcement announcement) {
-      this.id = announcement.getId();
-      this.title = announcement.getTitle();
-      this.isPinned = announcement.getIsPinned();
-    }
+    private String createdAt;
+    private String updatedAt;
   }
 
   @Builder
   @Getter
   public static class AnnouncementGetDetailResponse {
+    private Long id;
     private String title;
     private String content;
     private String imageUrl;

--- a/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
+++ b/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
@@ -3,12 +3,34 @@ package com.youngcamp.server.helper;
 import com.youngcamp.server.domain.Announcement;
 import com.youngcamp.server.dto.AnnouncementResponse;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class AnnouncementHelper {
+
+  public static List<AnnouncementResponse.AnnouncementGetResponse> toDto(
+          List<Announcement> announcement) {
+    List<AnnouncementResponse.AnnouncementGetResponse> dto = announcement.stream()
+            .map(a ->
+                    AnnouncementResponse.AnnouncementGetResponse.builder()
+                            .id(a.getId())
+                            .title(a.getTitle())
+                            .isPinned(a.getIsPinned())
+                            .createdAt(String.valueOf(a.getCreatedAt()))
+                            .updatedAt(String.valueOf(a.getUpdatedAt()))
+                            .build()
+            )
+            .collect(Collectors.toList());
+    List<AnnouncementResponse.AnnouncementGetResponse> collect = dto;
+
+    return dto;
+  }
 
   public static AnnouncementResponse.AnnouncementGetDetailResponse toDto(
       Announcement announcement) {
     AnnouncementResponse.AnnouncementGetDetailResponse dto =
         AnnouncementResponse.AnnouncementGetDetailResponse.builder()
+            .id(announcement.getId())
             .title(announcement.getTitle())
             .content(announcement.getContent())
             .imageUrl(announcement.getImageUrl())

--- a/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
+++ b/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
@@ -2,24 +2,24 @@ package com.youngcamp.server.helper;
 
 import com.youngcamp.server.domain.Announcement;
 import com.youngcamp.server.dto.AnnouncementResponse;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class AnnouncementHelper {
 
   public static List<AnnouncementResponse.AnnouncementGetResponse> toDto(
-          List<Announcement> announcement) {
-    List<AnnouncementResponse.AnnouncementGetResponse> dto = announcement.stream()
-            .map(a ->
+      List<Announcement> announcement) {
+    List<AnnouncementResponse.AnnouncementGetResponse> dto =
+        announcement.stream()
+            .map(
+                a ->
                     AnnouncementResponse.AnnouncementGetResponse.builder()
-                            .id(a.getId())
-                            .title(a.getTitle())
-                            .isPinned(a.getIsPinned())
-                            .createdAt(String.valueOf(a.getCreatedAt()))
-                            .updatedAt(String.valueOf(a.getUpdatedAt()))
-                            .build()
-            )
+                        .id(a.getId())
+                        .title(a.getTitle())
+                        .isPinned(a.getIsPinned())
+                        .createdAt(String.valueOf(a.getCreatedAt()))
+                        .updatedAt(String.valueOf(a.getUpdatedAt()))
+                        .build())
             .collect(Collectors.toList());
     List<AnnouncementResponse.AnnouncementGetResponse> collect = dto;
 

--- a/src/main/java/com/youngcamp/server/service/AnnouncementService.java
+++ b/src/main/java/com/youngcamp/server/service/AnnouncementService.java
@@ -5,7 +5,6 @@ import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementDeleteRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementEditRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementPostRequest;
 import com.youngcamp.server.dto.AnnouncementResponse.AnnouncementEditResponse;
-import com.youngcamp.server.dto.AnnouncementResponse.AnnouncementGetResponse;
 import com.youngcamp.server.dto.AnnouncementResponse.AnnouncementPostResponse;
 import com.youngcamp.server.exception.NotFoundException;
 import com.youngcamp.server.repository.AnnouncementRepository;

--- a/src/main/java/com/youngcamp/server/service/AnnouncementService.java
+++ b/src/main/java/com/youngcamp/server/service/AnnouncementService.java
@@ -62,10 +62,8 @@ public class AnnouncementService {
     }
   }
 
-  public List<AnnouncementGetResponse> getAnnouncements() {
-    return announcementRepository.findAllOrderByCreatedAtDesc().stream()
-        .map(AnnouncementGetResponse::new)
-        .collect(Collectors.toList());
+  public List<Announcement> getAnnouncements() {
+    return announcementRepository.findAllOrderByCreatedAtDesc();
   }
 
   public Announcement getDetailAnnouncement(Long announcementId) {
@@ -99,12 +97,8 @@ public class AnnouncementService {
     return AnnouncementEditResponse.builder().id(announcement.getId()).build();
   }
 
-  public List<AnnouncementGetResponse> searchAnnouncements(String keyword) {
-    List<Announcement> foundAnnouncements =
-        announcementRepository.findByTitleLikeOrderByCreatedAtDesc(keyword);
+  public List<Announcement> searchAnnouncements(String keyword) {
 
-    return foundAnnouncements.stream()
-        .map(AnnouncementGetResponse::new)
-        .collect(Collectors.toList());
+    return announcementRepository.findByTitleLikeOrderByCreatedAtDesc(keyword);
   }
 }

--- a/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @TestPropertySource("classpath:application-test.yml")
 @Transactional
 public class AnnouncementControllerTest {


### PR DESCRIPTION
## 📝 작업 내용
> 작업 내용을 자세하게 써 주세요.  
> ex) REST Controller 추가 (파일이름) 등
- AnnouncementHelper에 List<Announcement> to GetResponseDto 변환 메서드 추가
- AnnouncementControllerTest의 환경이 Test용 DB로 돌아가도록 test 프로파일 활성화 어노테이션 추가

## #️⃣ 이슈 트래킹
> 해당 작업과 연결 되어있는 이슈를 태그 해 주세요.  
> ex) #이슈번호
