### PR TITLE
Feat: 공지사항 언어 추가

### DIFF
--- a/src/main/java/com/youngcamp/server/domain/Announcement.java
+++ b/src/main/java/com/youngcamp/server/domain/Announcement.java
@@ -3,6 +3,8 @@ package com.youngcamp.server.domain;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementEditRequest;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 
 @Entity
@@ -11,19 +13,9 @@ import lombok.*;
 @Builder
 @Getter
 public class Announcement {
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-
-  @Column(nullable = false)
-  private String title;
-
-  @Column(nullable = false, columnDefinition = "text")
-  private String content;
-
-  @Column(name = "contenten", nullable = false, columnDefinition = "text")
-  private String contentEn;
 
   @Column(nullable = false)
   private Boolean isPinned;
@@ -37,13 +29,22 @@ public class Announcement {
 
   private LocalDateTime updatedAt;
 
+  @OneToMany(
+      mappedBy = "announcement",
+      cascade = CascadeType.ALL,
+      fetch = FetchType.LAZY,
+      orphanRemoval = true)
+  @Builder.Default
+  private List<AnnouncementContents> contents = new ArrayList<>();;
+
+  public void addContents(List<AnnouncementContents> contents) {
+    this.contents.addAll(contents);
+  }
+
   public void editAnnouncement(AnnouncementEditRequest request) {
-    this.title = request.getTitle();
-    this.content = request.getContent();
-    this.contentEn = request.getContentEn();
+    this.isPinned = request.getIsPinned();
     this.imageUrl = request.getImageUrl();
     this.fileUrl = request.getFileUrl();
-    this.isPinned = request.getIsPinned();
     this.updatedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/youngcamp/server/domain/Announcement.java
+++ b/src/main/java/com/youngcamp/server/domain/Announcement.java
@@ -22,6 +22,9 @@ public class Announcement {
   @Column(nullable = false, columnDefinition = "text")
   private String content;
 
+  @Column(name = "contenten", nullable = false, columnDefinition = "text")
+  private String contentEn;
+
   @Column(nullable = false)
   private Boolean isPinned;
 
@@ -37,6 +40,7 @@ public class Announcement {
   public void editAnnouncement(AnnouncementEditRequest request) {
     this.title = request.getTitle();
     this.content = request.getContent();
+    this.contentEn = request.getContentEn();
     this.imageUrl = request.getImageUrl();
     this.fileUrl = request.getFileUrl();
     this.isPinned = request.getIsPinned();

--- a/src/main/java/com/youngcamp/server/domain/AnnouncementContents.java
+++ b/src/main/java/com/youngcamp/server/domain/AnnouncementContents.java
@@ -1,0 +1,37 @@
+package com.youngcamp.server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class AnnouncementContents {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "announcement_id", nullable = false)
+  private Announcement announcement;
+
+  @Column(nullable = false)
+  private String languageCode;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String content;
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+}

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementRequest.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementRequest.java
@@ -16,6 +16,7 @@ public class AnnouncementRequest {
   public static class AnnouncementPostRequest {
     private String title;
     private String content;
+    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;
@@ -37,6 +38,7 @@ public class AnnouncementRequest {
   public static class AnnouncementEditRequest {
     private String title;
     private String content;
+    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementRequest.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementRequest.java
@@ -14,12 +14,10 @@ public class AnnouncementRequest {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class AnnouncementPostRequest {
-    private String title;
-    private String content;
-    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;
+    private List<AnnouncementTrRequest> contents;
   }
 
   @Getter
@@ -36,11 +34,19 @@ public class AnnouncementRequest {
   @AllArgsConstructor
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class AnnouncementEditRequest {
-    private String title;
-    private String content;
-    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;
+    private List<AnnouncementTrRequest> contents;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class AnnouncementTrRequest {
+    private String languageCode;
+    private String title;
+    private String content;
   }
 }

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
@@ -1,5 +1,6 @@
 package com.youngcamp.server.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,23 +27,31 @@ public class AnnouncementResponse {
   @Builder
   public static class AnnouncementGetResponse {
     private Long id;
-    private String title;
     private Boolean isPinned;
     private String createdAt;
     private String updatedAt;
+    private List<AnnouncementTrResponse> contents;
   }
 
   @Builder
   @Getter
   public static class AnnouncementGetDetailResponse {
     private Long id;
-    private String title;
-    private String content;
-    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;
     private String createdAt;
     private String updatedAt;
+    private List<AnnouncementTrResponse> contents;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class AnnouncementTrResponse {
+    private String languageCode;
+    private String title;
+    private String content;
   }
 }

--- a/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
+++ b/src/main/java/com/youngcamp/server/dto/AnnouncementResponse.java
@@ -38,6 +38,7 @@ public class AnnouncementResponse {
     private Long id;
     private String title;
     private String content;
+    private String contentEn;
     private String imageUrl;
     private String fileUrl;
     private Boolean isPinned;

--- a/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
+++ b/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
@@ -33,6 +33,7 @@ public class AnnouncementHelper {
             .id(announcement.getId())
             .title(announcement.getTitle())
             .content(announcement.getContent())
+            .contentEn(announcement.getContentEn())
             .imageUrl(announcement.getImageUrl())
             .fileUrl(announcement.getFileUrl())
             .isPinned(announcement.getIsPinned())

--- a/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
+++ b/src/main/java/com/youngcamp/server/helper/AnnouncementHelper.java
@@ -1,6 +1,7 @@
 package com.youngcamp.server.helper;
 
 import com.youngcamp.server.domain.Announcement;
+import com.youngcamp.server.domain.AnnouncementContents;
 import com.youngcamp.server.dto.AnnouncementResponse;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,39 +9,58 @@ import java.util.stream.Collectors;
 public class AnnouncementHelper {
 
   public static List<AnnouncementResponse.AnnouncementGetResponse> toDto(
-      List<Announcement> announcement) {
+      List<Announcement> announcements) {
     List<AnnouncementResponse.AnnouncementGetResponse> dto =
-        announcement.stream()
+        announcements.stream()
             .map(
-                a ->
-                    AnnouncementResponse.AnnouncementGetResponse.builder()
-                        .id(a.getId())
-                        .title(a.getTitle())
-                        .isPinned(a.getIsPinned())
-                        .createdAt(String.valueOf(a.getCreatedAt()))
-                        .updatedAt(String.valueOf(a.getUpdatedAt()))
-                        .build())
+                a -> {
+                  String translatedTitle =
+                      a.getContents().stream()
+                          .map(AnnouncementContents::getTitle)
+                          .findFirst()
+                          .orElse("정보없음");
+
+                  return AnnouncementResponse.AnnouncementGetResponse.builder()
+                      .id(a.getId())
+                      .isPinned(a.getIsPinned())
+                      .createdAt(String.valueOf(a.getCreatedAt()))
+                      .updatedAt(String.valueOf(a.getUpdatedAt()))
+                      .contents(
+                          a.getContents().stream()
+                              .map(
+                                  t ->
+                                      AnnouncementResponse.AnnouncementTrResponse.builder()
+                                          .languageCode(t.getLanguageCode())
+                                          .title(t.getTitle())
+                                          .content(t.getContent())
+                                          .build())
+                              .collect(Collectors.toList()))
+                      .build();
+                })
             .collect(Collectors.toList());
-    List<AnnouncementResponse.AnnouncementGetResponse> collect = dto;
 
     return dto;
   }
 
   public static AnnouncementResponse.AnnouncementGetDetailResponse toDto(
       Announcement announcement) {
-    AnnouncementResponse.AnnouncementGetDetailResponse dto =
-        AnnouncementResponse.AnnouncementGetDetailResponse.builder()
-            .id(announcement.getId())
-            .title(announcement.getTitle())
-            .content(announcement.getContent())
-            .contentEn(announcement.getContentEn())
-            .imageUrl(announcement.getImageUrl())
-            .fileUrl(announcement.getFileUrl())
-            .isPinned(announcement.getIsPinned())
-            .createdAt(String.valueOf(announcement.getCreatedAt()))
-            .updatedAt(String.valueOf(announcement.getUpdatedAt()))
-            .build();
-
-    return dto;
+    return AnnouncementResponse.AnnouncementGetDetailResponse.builder()
+        .id(announcement.getId())
+        .imageUrl(announcement.getImageUrl())
+        .fileUrl(announcement.getFileUrl())
+        .isPinned(announcement.getIsPinned())
+        .createdAt(String.valueOf(announcement.getCreatedAt()))
+        .updatedAt(String.valueOf(announcement.getUpdatedAt()))
+        .contents(
+            announcement.getContents().stream()
+                .map(
+                    t ->
+                        AnnouncementResponse.AnnouncementTrResponse.builder()
+                            .languageCode(t.getLanguageCode())
+                            .title(t.getTitle())
+                            .content(t.getContent())
+                            .build())
+                .collect(Collectors.toList()))
+        .build();
   }
 }

--- a/src/main/java/com/youngcamp/server/repository/AnnouncementRepository.java
+++ b/src/main/java/com/youngcamp/server/repository/AnnouncementRepository.java
@@ -2,6 +2,7 @@ package com.youngcamp.server.repository;
 
 import com.youngcamp.server.domain.Announcement;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,10 +19,16 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
   @Query(value = "select a.id from Announcement a where a.id in :announcementIds")
   List<Long> findExistingIds(@Param("announcementIds") List<Long> ids);
 
+  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.contents ORDER BY a.createdAt DESC")
+  List<Announcement> findAllWithContents();
+
+  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.contents WHERE a.id = :id")
+  Optional<Announcement> findByIdWithContents(@Param("id") Long id);
+
   @Query(
       value =
-          "select a from Announcement a where a.title like %:keyword% order by a.createdAt desc")
-  List<Announcement> findByTitleLikeOrderByCreatedAtDesc(String keyword);
+          "select a from Announcement a join a.contents t where t.title like %:keyword% order by a.createdAt desc")
+  List<Announcement> findByTitleLikeOrderByCreatedAtDesc(@Param("keyword") String keyword);
 
   @Query(value = "select a from Announcement a order by a.createdAt desc")
   List<Announcement> findAllOrderByCreatedAtDesc();

--- a/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
@@ -69,6 +69,7 @@ public class AnnouncementControllerTest {
         AnnouncementPostRequest.builder()
             .title("title")
             .content("content")
+            .contentEn("contentEn")
             .imageUrl("image.jpg")
             .isPinned(true)
             .build();
@@ -129,6 +130,7 @@ public class AnnouncementControllerTest {
                     Announcement.builder()
                         .title("title" + i)
                         .content("content" + i)
+                        .contentEn("contentEn" + i)
                         .imageUrl("imageUrl" + i)
                         .isPinned(true)
                         .build())
@@ -154,6 +156,7 @@ public class AnnouncementControllerTest {
         Announcement.builder()
             .title("title")
             .content("content")
+            .contentEn("contentEn")
             .imageUrl("imageUrl")
             .isPinned(true)
             .build();
@@ -178,6 +181,7 @@ public class AnnouncementControllerTest {
         Announcement.builder()
             .title("old title")
             .content("old content")
+            .contentEn("old contentEn")
             .imageUrl("old image")
             .isPinned(false)
             .build();
@@ -187,6 +191,7 @@ public class AnnouncementControllerTest {
         AnnouncementEditRequest.builder()
             .title("new title")
             .content("new content")
+            .contentEn("new contentEn")
             .imageUrl("new image")
             .isPinned(true)
             .build();
@@ -230,6 +235,7 @@ public class AnnouncementControllerTest {
                     Announcement.builder()
                         .title("title" + i)
                         .content("content" + i)
+                        .contentEn("contentEn" + i)
                         .imageUrl("imageUrl" + i)
                         .isPinned(true)
                         .build())

--- a/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/youngcamp/server/controller/AnnouncementControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.youngcamp.server.domain.Announcement;
+import com.youngcamp.server.domain.AnnouncementContents;
+import com.youngcamp.server.dto.AnnouncementRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementDeleteRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementEditRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementPostRequest;
@@ -14,7 +16,6 @@ import com.youngcamp.server.repository.AnnouncementRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,11 +67,20 @@ public class AnnouncementControllerTest {
     final String url = "/api/announcements";
     AnnouncementPostRequest request =
         AnnouncementPostRequest.builder()
-            .title("title")
-            .content("content")
-            .contentEn("contentEn")
             .imageUrl("image.jpg")
             .isPinned(true)
+            .contents(
+                List.of(
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("ko")
+                        .title("타이틀")
+                        .content("컨텐츠")
+                        .build(),
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("en")
+                        .title("Etitle")
+                        .content("Econtent")
+                        .build()))
             .build();
     String json = mapper.writeValueAsString(request);
 
@@ -91,22 +100,36 @@ public class AnnouncementControllerTest {
     List<Announcement> announcements =
         IntStream.range(0, 10)
             .mapToObj(
-                i ->
-                    Announcement.builder()
-                        .title("title" + i)
-                        .content("content" + i)
-                        .imageUrl("imageUrl" + i)
-                        .isPinned(true)
-                        .build())
+                i -> {
+                  Announcement announcement =
+                      Announcement.builder().imageUrl("imageUrl" + i).isPinned(true).build();
+
+                  AnnouncementContents translationKo =
+                      AnnouncementContents.builder()
+                          .announcement(announcement)
+                          .languageCode("ko")
+                          .title("타이틀" + i)
+                          .content("컨텐츠" + i)
+                          .build();
+
+                  AnnouncementContents translationEn =
+                      AnnouncementContents.builder()
+                          .announcement(announcement)
+                          .languageCode("en")
+                          .title("Etitle" + i)
+                          .content("Econtent" + i)
+                          .build();
+
+                  announcement.addContents(List.of(translationKo, translationEn));
+                  return announcement;
+                })
             .collect(Collectors.toList());
+
     List<Announcement> savedAnnouncements = announcementRepository.saveAll(announcements);
 
-    Long id = announcements.get(0).getId();
-    System.out.println(id);
-
-    List<Long> collect =
-        savedAnnouncements.stream().map(a -> a.getId()).collect(Collectors.toList());
-    AnnouncementDeleteRequest request = AnnouncementDeleteRequest.builder().ids(collect).build();
+    List<Long> ids =
+        savedAnnouncements.stream().map(Announcement::getId).collect(Collectors.toList());
+    AnnouncementDeleteRequest request = AnnouncementDeleteRequest.builder().ids(ids).build();
     String json = mapper.writeValueAsString(request);
 
     // expected
@@ -116,6 +139,10 @@ public class AnnouncementControllerTest {
                 .content(json)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
+
+    // 삭제 확인
+    List<Announcement> remainingAnnouncements = announcementRepository.findAll();
+    assertThat(remainingAnnouncements).isEmpty();
   }
 
   @Test
@@ -126,16 +153,30 @@ public class AnnouncementControllerTest {
     List<Announcement> announcements =
         IntStream.range(0, 15)
             .mapToObj(
-                i ->
-                    Announcement.builder()
-                        .title("title" + i)
-                        .content("content" + i)
-                        .contentEn("contentEn" + i)
-                        .imageUrl("imageUrl" + i)
-                        .isPinned(true)
-                        .build())
+                i -> {
+                  Announcement announcement =
+                      Announcement.builder().imageUrl("imageUrl" + i).isPinned(true).build();
+
+                  AnnouncementContents translationKo =
+                      AnnouncementContents.builder()
+                          .announcement(announcement)
+                          .languageCode("ko")
+                          .title("타이틀" + i)
+                          .content("컨텐츠" + i)
+                          .build();
+
+                  AnnouncementContents translationEn =
+                      AnnouncementContents.builder()
+                          .announcement(announcement)
+                          .languageCode("en")
+                          .title("Etitle" + i)
+                          .content("Econtent" + i)
+                          .build();
+
+                  announcement.addContents(List.of(translationKo, translationEn));
+                  return announcement;
+                })
             .collect(Collectors.toList());
-    System.out.println(announcements.size());
 
     announcementRepository.saveAll(announcements);
 
@@ -144,7 +185,9 @@ public class AnnouncementControllerTest {
         .perform(MockMvcRequestBuilders.get(url).contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.length()").value(15));
+        .andExpect(jsonPath("$.data.length()").value(15))
+        .andExpect(jsonPath("$.data[0].translations[1].title").value("Ktitle0"))
+        .andExpect(jsonPath("$.data[0].translations[0].title").value("Etitle0"));
   }
 
   @Test
@@ -152,23 +195,35 @@ public class AnnouncementControllerTest {
     // given
     final String url = "/api/announcements/{announcementId}";
 
-    Announcement announcement =
-        Announcement.builder()
-            .title("title")
-            .content("content")
-            .contentEn("contentEn")
-            .imageUrl("imageUrl")
-            .isPinned(true)
+    Announcement announcement = Announcement.builder().imageUrl("imageUrl").isPinned(true).build();
+
+    AnnouncementContents translationKo =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("ko")
+            .title("타이틀")
+            .content("콘텐츠")
             .build();
+
+    AnnouncementContents translationEn =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("en")
+            .title("Etitle")
+            .content("Eontent")
+            .build();
+
+    announcement.addContents(List.of(translationKo, translationEn));
+
     Announcement savedAnnouncement = announcementRepository.save(announcement);
 
-    // expected
     mockMvc
         .perform(
             MockMvcRequestBuilders.get(url, savedAnnouncement.getId())
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.title").value("title"));
+        .andExpect(jsonPath("$.data.translations[1].title").value("Ktitle"))
+        .andExpect(jsonPath("$.data.translations[0].title").value("Etitle"));
   }
 
   @Test
@@ -178,72 +233,96 @@ public class AnnouncementControllerTest {
     final String url = "/api/announcements/{announcementId}";
 
     Announcement oldAnnouncement =
-        Announcement.builder()
-            .title("old title")
-            .content("old content")
-            .contentEn("old contentEn")
-            .imageUrl("old image")
-            .isPinned(false)
-            .build();
+        Announcement.builder().imageUrl("old image").isPinned(false).build();
+
     Announcement savedAnnouncement = announcementRepository.save(oldAnnouncement);
 
     AnnouncementEditRequest request =
         AnnouncementEditRequest.builder()
-            .title("new title")
-            .content("new content")
-            .contentEn("new contentEn")
             .imageUrl("new image")
             .isPinned(true)
+            .contents(
+                List.of(
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("ko")
+                        .title("신규 타이틀")
+                        .content("신규 콘텐츠")
+                        .build(),
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("en")
+                        .title("New Etitle")
+                        .content("New Econtent")
+                        .build()))
             .build();
 
     String json = mapper.writeValueAsString(request);
 
     // expected
-    ResultActions resultActions =
-        mockMvc
-            .perform(
-                MockMvcRequestBuilders.patch(url, savedAnnouncement.getId())
-                    .content(json)
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andDo(print())
-            .andExpect(jsonPath("$.data.id").value(savedAnnouncement.getId()));
-
-    Announcement result = announcementRepository.findById(savedAnnouncement.getId()).get();
-    Assertions.assertThat(result.getTitle()).isEqualTo("new title");
-    Assertions.assertThat(result.getContent()).isEqualTo("new content");
-    Assertions.assertThat(result.getImageUrl()).isEqualTo("new image");
-    Assertions.assertThat(result.getIsPinned()).isEqualTo(true);
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(url, savedAnnouncement.getId())
+                .content(json)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.id").value(savedAnnouncement.getId()));
   }
 
   @Test
   public void 공지사항검색() throws Exception {
     // given
-    Announcement announcement =
-        Announcement.builder()
+    Announcement announcement = Announcement.builder().imageUrl("이미지.jpg").isPinned(true).build();
+
+    AnnouncementContents translationKo =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("ko")
             .title("타이틀")
             .content("컨텐츠")
-            .imageUrl("이미지.jpg")
-            .isPinned(true)
             .build();
+
+    AnnouncementContents translationEn =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("en")
+            .title("title")
+            .content("CEnglish")
+            .build();
+
+    announcement.addContents(List.of(translationKo, translationEn));
     announcementRepository.save(announcement);
 
     List<Announcement> announcements =
         IntStream.range(0, 3)
             .mapToObj(
-                i ->
-                    Announcement.builder()
-                        .title("title" + i)
-                        .content("content" + i)
-                        .contentEn("contentEn" + i)
-                        .imageUrl("imageUrl" + i)
-                        .isPinned(true)
-                        .build())
+                i -> {
+                  Announcement ann =
+                      Announcement.builder().imageUrl("imageUrl" + i).isPinned(true).build();
+
+                  AnnouncementContents koTrans =
+                      AnnouncementContents.builder()
+                          .announcement(ann)
+                          .languageCode("ko")
+                          .title("타이틀" + i)
+                          .content("컨텐츠" + i)
+                          .build();
+
+                  AnnouncementContents enTrans =
+                      AnnouncementContents.builder()
+                          .announcement(ann)
+                          .languageCode("en")
+                          .title("title" + i)
+                          .content("content" + i)
+                          .build();
+
+                  ann.addContents(List.of(koTrans, enTrans));
+                  return ann;
+                })
             .collect(Collectors.toList());
+
     announcementRepository.saveAll(announcements);
 
-    final String url = "/api/announcements/search?keyword=tle";
-    String keyword = "tle";
+    final String url = "/api/announcements/search?keyword=title";
+    String keyword = "title";
 
     // expected
     mockMvc

--- a/src/test/java/com/youngcamp/server/repository/AnnouncementRepositoryTest.java
+++ b/src/test/java/com/youngcamp/server/repository/AnnouncementRepositoryTest.java
@@ -195,11 +195,10 @@ public class AnnouncementRepositoryTest {
 
     // then
     assertThat(results.size()).isEqualTo(20);
-    // AnnouncementTranslation에서 title을 가져와서 검증
     Announcement firstAnnouncement = results.get(0);
     AnnouncementContents firstTranslation =
         firstAnnouncement.getContents().stream()
-            .filter(t -> "ko".equals(t.getLanguageCode())) // 한국어 번역 데이터 확인
+            .filter(t -> "ko".equals(t.getLanguageCode()))
             .findFirst()
             .orElseThrow(() -> new RuntimeException("한국어 번역이 존재하지 않습니다."));
 
@@ -225,8 +224,8 @@ public class AnnouncementRepositoryTest {
         AnnouncementContents.builder()
             .announcement(announcement)
             .languageCode("en")
-            .title("English title")
-            .content("English content")
+            .title("Etitle")
+            .content("Econtent")
             .build();
 
     announcement.addContents(List.of(translationKo, translationEn));
@@ -240,7 +239,6 @@ public class AnnouncementRepositoryTest {
 
     Announcement foundAnnouncement = result.get();
 
-    // 한국어 번역 검증
     AnnouncementContents koTranslation =
         foundAnnouncement.getContents().stream()
             .filter(t -> "ko".equals(t.getLanguageCode()))
@@ -250,7 +248,6 @@ public class AnnouncementRepositoryTest {
     assertThat(koTranslation.getTitle()).isEqualTo("타이틀");
     assertThat(koTranslation.getContent()).isEqualTo("콘텐츠");
 
-    // 영어 번역 검증
     AnnouncementContents enTranslation =
         foundAnnouncement.getContents().stream()
             .filter(t -> "en".equals(t.getLanguageCode()))

--- a/src/test/java/com/youngcamp/server/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/youngcamp/server/service/AnnouncementServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.youngcamp.server.domain.Announcement;
+import com.youngcamp.server.domain.AnnouncementContents;
+import com.youngcamp.server.dto.AnnouncementRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementDeleteRequest;
 import com.youngcamp.server.dto.AnnouncementRequest.AnnouncementPostRequest;
 import com.youngcamp.server.dto.AnnouncementResponse.AnnouncementPostResponse;
@@ -27,8 +29,6 @@ public class AnnouncementServiceTest {
 
   @InjectMocks private AnnouncementService target;
 
-  private final String title = "title";
-  private final String content = "content";
   private final String imageUrl = "s3-image-url";
   private final Boolean isPinned = true;
 
@@ -38,10 +38,20 @@ public class AnnouncementServiceTest {
     doReturn(announcement()).when(announcementRepository).save(any(Announcement.class));
     AnnouncementPostRequest request =
         AnnouncementPostRequest.builder()
-            .title(title)
-            .content(content)
             .imageUrl(imageUrl)
             .isPinned(isPinned)
+            .contents(
+                Arrays.asList(
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("ko")
+                        .title("Ktitle")
+                        .content("Kcontent")
+                        .build(),
+                    AnnouncementRequest.AnnouncementTrRequest.builder()
+                        .languageCode("en")
+                        .title("Etitle")
+                        .content("Econtent")
+                        .build()))
             .build();
 
     // when
@@ -87,12 +97,27 @@ public class AnnouncementServiceTest {
   }
 
   private Announcement announcement() {
-    return Announcement.builder()
-        .id(-1L)
-        .title(title)
-        .content(content)
-        .imageUrl(imageUrl)
-        .isPinned(isPinned)
-        .build();
+    Announcement announcement =
+        Announcement.builder().id(-1L).imageUrl(imageUrl).isPinned(isPinned).build();
+
+    AnnouncementContents translationKo =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("ko")
+            .title("Ktitle")
+            .content("Kcontent")
+            .build();
+
+    AnnouncementContents translationEn =
+        AnnouncementContents.builder()
+            .announcement(announcement)
+            .languageCode("en")
+            .title("Etitle")
+            .content("Econtent")
+            .build();
+
+    announcement.addContents(Arrays.asList(translationKo, translationEn));
+
+    return announcement;
   }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 읽기/쓰기에서 다양한 언어를 지원합니다.
![image](https://github.com/user-attachments/assets/bde9d4ce-723e-487f-b0e0-2ad99538d957)
위 사진처럼 data 내에 배열로 들어 가 있어요.  
통상 [0]번이 korean, [1]번이 영어입니다

## #️⃣ 이슈 트래킹
> 지금 테스트코드가 안 돌아가서... 뒤를 부탁 드리겠습니다... 😢 
